### PR TITLE
Parse network configuration from a `team.toml`

### DIFF
--- a/meta-hulks/conf/distro/HULKs-OS.conf
+++ b/meta-hulks/conf/distro/HULKs-OS.conf
@@ -4,5 +4,5 @@ SUMMARY = "HULKs flavoured Poky"
 
 DISTRO = "HULKs-OS"
 DISTRO_NAME = "HULKs-OS"
-DISTRO_VERSION = "7.5.6"
+DISTRO_VERSION = "7.5.7"
 SDKIMAGE_FEATURES:remove = "dbg-pkgs src-pkgs"

--- a/meta-hulks/recipes-hulks/network-config/network-config.bb
+++ b/meta-hulks/recipes-hulks/network-config/network-config.bb
@@ -1,4 +1,10 @@
-DEPENDS += "nao-wifi-conf"
+DEPENDS += "\
+            nao-wifi-conf\
+           "
+RDEPENDS:${PN} += "\
+                   env \
+                  "
+
 
 SUMMARY = "Add systemd services to initially set ip address config"
 LICENSE = "GPL-3.0-only"

--- a/meta-hulks/recipes-hulks/network-config/network-config.bb
+++ b/meta-hulks/recipes-hulks/network-config/network-config.bb
@@ -1,10 +1,6 @@
 DEPENDS += "\
             nao-wifi-conf\
            "
-RDEPENDS:${PN} += "\
-                   env \
-                  "
-
 
 SUMMARY = "Add systemd services to initially set ip address config"
 LICENSE = "GPL-3.0-only"

--- a/meta-hulks/recipes-hulks/network-config/network-config/configure_network
+++ b/meta-hulks/recipes-hulks/network-config/network-config/configure_network
@@ -1,36 +1,149 @@
-#!/bin/sh
+#!/bin/env python
+"""Configure the network of the NAO.
 
-set -e
+This script configures the network of the NAO based on the hardware IDs and the
+team number. It then composes the configuration for the WLAN and wired network
+based on the team number and the number of the NAO, and sets the hostname.
+"""
 
-HEAD_ID="$(/opt/aldebaran/bin/head_id)"
-QUERY_STRING="to_entries | map(select(.value.head_id == \"${HEAD_ID}\")) | .[0].key"
-NAO_NUMBER="$(jq -r "${QUERY_STRING}" /media/internal/hardware_ids.json)"
+from __future__ import annotations
 
-if [ -z "${NAO_NUMBER}" ]; then
-  exit
-fi
+from pathlib import Path
+from subprocess import check_call, check_output
+from typing import Any
 
-HOSTNAME="tuhhnao${NAO_NUMBER}"
+import tomllib
 
-echo "[Match]
+TEAM_TOML = "/media/internal/team.toml"
+HEAD_ID_SCRIPT = "/opt/aldebaran/bin/head_id"
+WLAN_NETWORK_PATH = "/etc/systemd/network/80-wlan.network"
+WIRED_NETWORK_PATH = "/etc/systemd/network/80-wired.network"
+
+
+def load_configuration(path: Path | str) -> dict[str, Any]:
+    """Load the configuration from the given path.
+
+    Args:
+        path: Path to the configuration file.
+
+    Returns:
+        The configuration
+
+    """
+    path = Path(path)
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def query_head_id() -> str:
+    """Query the head ID of the NAO.
+
+    Returns:
+        The head ID of the NAO.
+
+    """
+    command = HEAD_ID_SCRIPT.split()
+    return check_output(command, encoding="UTF-8")
+
+
+def find_nao_with_head_id(
+    configuration: dict[str, Any],
+    head_id: str,
+) -> dict[str, Any]:
+    """Find the NAO with the given head ID in the configuration.
+
+    Args:
+        configuration: The configuration.
+        head_id: The head ID of the NAO.
+
+    Returns:
+        The NAO with the given head ID.
+
+    """
+    try:
+        return next(x for x in configuration["naos"] if x["head_id"] == head_id)
+    except StopIteration as error:
+        msg = f"Could not find NAO with head_id {head_id}"
+        raise ValueError(msg) from error
+
+
+def compose_wlan_network(nao: dict[str, Any], team_number: int) -> str:
+    """Compose the configuration for the WLAN network.
+
+    Args:
+        nao: The NAO.
+        team_number: The team number.
+
+    Returns:
+        The configuration for the WLAN network.
+
+    """
+    return f"""\
+[Match]
 Name=wlan*
 
 [Network]
-Address=10.0.24.${NAO_NUMBER}/16
+Address=10.0.{team_number}.{nao["number"]}/16
 
 [Route]
-Gateway=0.0.0.0
-" > /etc/systemd/network/80-wlan.network
+Gateway=0.0.0.0"""
 
-echo "[Match]
+
+def compose_wired_network(nao: dict[str, Any], team_number: int) -> str:
+    """Compose the configuration for the wired network.
+
+    Args:
+        nao: The NAO.
+        team_number: The team number.
+
+    Returns:
+        The configuration for the wired network.
+
+    """
+    return f"""\
+[Match]
 Name=en* eth*
 
 [Network]
-Address=10.1.24.${NAO_NUMBER}/16
+Address=10.1.{team_number}.{nao["number"]}/16
 
 [Route]
 Gateway=10.1.24.1
-Destination=10.2.24.0/24
-" > /etc/systemd/network/80-wired.network
+Destination=10.2.24.0/24"""
 
-hostnamectl set-hostname ${HOSTNAME}
+
+def write_to_file(path: str | Path, content: str) -> None:
+    """Write the content to the file at the given path.
+
+    Args:
+        path: Path to the file.
+        content: Content to write.
+
+    """
+    path = Path(path)
+    with path.open("w") as file:
+        file.write(content)
+
+
+def set_hostname(hostname: str) -> None:
+    """Set the hostname of the NAO.
+
+    Args:
+        hostname: The hostname.
+
+    """
+    check_call(["/usr/bin/echo", "set-hostname", hostname])
+
+
+if __name__ == "__main__":
+    configuration = load_configuration(TEAM_TOML)
+    head_id = query_head_id()
+    nao = find_nao_with_head_id(configuration, head_id)
+
+    hostname = f"{configuration["hostname_prefix"]}{nao["number"]}"
+    wlan_configuration = compose_wlan_network(nao, configuration["team_number"])
+    wired_configuration = compose_wired_network(nao, configuration["team_number"])
+
+    write_to_file(WLAN_NETWORK_PATH, wlan_configuration)
+    write_to_file(WIRED_NETWORK_PATH, wired_configuration)
+    set_hostname(hostname)

--- a/meta-hulks/recipes-hulks/network-config/network-config/configure_network
+++ b/meta-hulks/recipes-hulks/network-config/network-config/configure_network
@@ -135,7 +135,7 @@ def set_hostname(hostname: str) -> None:
         hostname: The hostname.
 
     """
-    check_call(["/usr/bin/echo", "set-hostname", hostname])
+    check_call(["/usr/bin/hostnamectl", "set-hostname", hostname])
 
 
 if __name__ == "__main__":

--- a/meta-hulks/recipes-hulks/network-config/network-config/configure_network
+++ b/meta-hulks/recipes-hulks/network-config/network-config/configure_network
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 """Configure the network of the NAO.
 
 This script configures the network of the NAO based on the hardware IDs and the
@@ -43,7 +43,8 @@ def query_head_id() -> str:
 
     """
     command = HEAD_ID_SCRIPT.split()
-    return check_output(command, encoding="UTF-8")
+    output = check_output(command, encoding="UTF-8")
+    return output.strip()
 
 
 def find_nao_with_head_id(
@@ -86,7 +87,8 @@ Name=wlan*
 Address=10.0.{team_number}.{nao["number"]}/16
 
 [Route]
-Gateway=0.0.0.0"""
+Gateway=0.0.0.0
+"""
 
 
 def compose_wired_network(nao: dict[str, Any], team_number: int) -> str:
@@ -109,7 +111,8 @@ Address=10.1.{team_number}.{nao["number"]}/16
 
 [Route]
 Gateway=10.1.24.1
-Destination=10.2.24.0/24"""
+Destination=10.2.24.0/24
+"""
 
 
 def write_to_file(path: str | Path, content: str) -> None:

--- a/meta-hulks/recipes-hulks/network-config/network-config/configure_network
+++ b/meta-hulks/recipes-hulks/network-config/network-config/configure_network
@@ -140,10 +140,9 @@ if __name__ == "__main__":
     head_id = query_head_id()
     nao = find_nao_with_head_id(configuration, head_id)
 
-    hostname = f"{configuration["hostname_prefix"]}{nao["number"]}"
     wlan_configuration = compose_wlan_network(nao, configuration["team_number"])
     wired_configuration = compose_wired_network(nao, configuration["team_number"])
 
     write_to_file(WLAN_NETWORK_PATH, wlan_configuration)
     write_to_file(WIRED_NETWORK_PATH, wired_configuration)
-    set_hostname(hostname)
+    set_hostname(nao["hostname"])


### PR DESCRIPTION
This pull request extends the configurable network devices by hostnames and team numbers. The information is parsed from a `team.toml` in `/media/internal/team.toml`.


### Dependency Management:
* [`meta-hulks/recipes-hulks/network-config/network-config.bb`](diffhunk://#diff-67d634618afac6b94c482c590a3fa62272045083ae212b4ae6722cbc819e0e93L1-R3): Reformatted the `DEPENDS` variable for better readability.

### Network Configuration Script Rewrite:
* `meta-hulks/recipes-hulks/network-config/network-config/configure_network`: Rewrote the network configuration script from shell to Python. This includes:
  - Switching the script from `sh` to `python`.
  - Adding detailed docstrings and type hints.
  - Using Python libraries such as `pathlib`, `subprocess`, and `tomllib` for handling file operations and subprocess calls.
  - Defining functions to load configuration, query head ID, find NAO by head ID, compose network configurations, write to files, and set the hostname.

### Necessary Version Increase:
* [`meta-hulks/conf/distro/HULKs-OS.conf`](diffhunk://#diff-d64e66d540dba74c51d6ce243b029dbb7d68a0192d09266e8e7af1f9a8814736L7-R7): Updated the `DISTRO_VERSION` from `7.5.6` to `7.5.7`.
