### PR TITLE
Always upload artifacts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,14 +27,22 @@ jobs:
         run: kas build --target nao-image --cmd populate_sdk meta-nao/kas/base.yml:meta-nao/kas/hulks.yml
       - name: Build SDK (aarch64)
         run: kas build --target nao-image --cmd populate_sdk meta-nao/kas/base.yml:meta-nao/kas/hulks.yml:meta-nao/kas/aarch64.yml
-      - name: Upload artifacts
+      - name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
-          name: all
-          path: |
-            build/tmp/deploy/images/nao-v6/nao-image-HULKs-OS-${{ env.version }}.ext3.gz.opn
-            build/tmp/deploy/sdk/HULKs-OS-x86_64-toolchain-${{ env.version }}.sh
-            build/tmp/deploy/sdk/HULKs-OS-aarch64-toolchain-${{ env.version }}.sh
+          name: image
+          path: build/tmp/deploy/images/nao-v6/nao-image-HULKs-OS-${{ env.version }}.ext3.gz.opn
+      - name: Upload x86_64 SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-x86_64
+          path: build/tmp/deploy/sdk/HULKs-OS-x86_64-toolchain-${{ env.version }}.sh
+      - name: Upload aarch64 SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-aarch64
+          path: build/tmp/deploy/sdk/HULKs-OS-aarch64-toolchain-${{ env.version }}.sh
+
   release:
     name: Release
     if: startsWith(github.ref, 'refs/tags/')
@@ -53,7 +61,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: all
+          merge-multiple: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build development image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           path: meta-nao
       - name: Checkout Yocto layers
         run: kas checkout meta-nao/kas/base.yml:meta-nao/kas/hulks.yml
@@ -50,8 +49,6 @@ jobs:
         run: sudo rm -rf /usr/local/lib/android
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: meta-nao
+      - name: Extract the version
+        run: echo "version=$(grep -P 'DISTRO_VERSION\s*=\s*".+"' meta-nao/meta-hulks/conf/distro/HULKs-OS.conf | cut -d\" -f2)" >> $GITHUB_ENV
       - name: Checkout Yocto layers
         run: kas checkout meta-nao/kas/base.yml:meta-nao/kas/hulks.yml
       - name: Populate aldebaran_binaries.tar.gz
@@ -27,13 +29,12 @@ jobs:
         run: kas build --target nao-image --cmd populate_sdk meta-nao/kas/base.yml:meta-nao/kas/hulks.yml:meta-nao/kas/aarch64.yml
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: all
           path: |
-            build/tmp/deploy/images/nao-v6/nao-image-HULKs-OS-${{ github.ref_name }}.ext3.gz.opn
-            build/tmp/deploy/sdk/HULKs-OS-x86_64-toolchain-${{ github.ref_name }}.sh
-            build/tmp/deploy/sdk/HULKs-OS-aarch64-toolchain-${{ github.ref_name }}.sh
+            build/tmp/deploy/images/nao-v6/nao-image-HULKs-OS-${{ env.version }}.ext3.gz.opn
+            build/tmp/deploy/sdk/HULKs-OS-x86_64-toolchain-${{ env.version }}.sh
+            build/tmp/deploy/sdk/HULKs-OS-aarch64-toolchain-${{ env.version }}.sh
   release:
     name: Release
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This PR changes the CI to always uploading the build artifacts.
This makes testing changes easier for reviewers, allowing them to download the corresponding artifacts from the CI.
